### PR TITLE
fix: update package.json to allow webpack bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nativescript-sqlite",
   "version": "1.1.2",
   "description": "A sqlite NativeScript module for Android and iOS",
-  "main": "sqlite.js",
+  "main": "sqlite",
   "nativescript": {
     "platforms": {
       "android": "1.4.0",


### PR DESCRIPTION
The `.js` extension of the `main` property in the `package.json` had to be removed. That way, webpack will be able to correctly reference the android or ios main file.

For more information check out the [Webpack article](http://docs.nativescript.org/tooling/bundling-with-webpack#referencing-platform-specific-modules-from-packagejson) in the NativeScript  documentation. 

fixes #40 