### PR TITLE
Update docs for db.version()

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -178,7 +178,7 @@ If Version number, then the database will be changed to the version you passed t
 ```js
 new Sqlite("test.db", function(err, db) {
   db.version(function(err, ver) {
-    if (ver === 0) {
+    if (ver == 0) {
       db.execSQL("Create table....");
       db.version(1); // Sets the version to 1
     }


### PR DESCRIPTION
The version is returned as a string, so == should be used in place of ===