### PR TITLE
Fix in-memory databases on android

### DIFF
--- a/demo/app/tests/dbAccess.js
+++ b/demo/app/tests/dbAccess.js
@@ -34,4 +34,17 @@ if (!sqlite.exists(dbName)) {
         });
 
     });
+
+    new sqlite(":memory:", function(err, db) {
+        describe('In-Memory Connection', function() {
+            it('Error should be null', function() { 
+                assert.isNull(err);
+            });
+            it('dbConnection should not be null', function() {
+                assert.isNotNull(db);
+            });
+
+            done();
+        });
+    });
 });

--- a/demo/app/tests/dbAccessPromise.js
+++ b/demo/app/tests/dbAccessPromise.js
@@ -39,4 +39,19 @@ describe('Database', function () {
             });
         });
     });
+
+    describe('In-Memory Connection', function () {
+        var promise = new sqlite(":memory:");
+        it('Promise should not be null', function () {
+            assert.isNotNull(promise);
+        });
+        it('promise should work', function (done) {
+            promise.then(function (db) {
+                assert.isNotNull(db);
+                
+                db.close();
+                done();
+            });
+        });
+    });
 });

--- a/src/sqlite.android.js
+++ b/src/sqlite.android.js
@@ -354,7 +354,7 @@ function Database(dbname, options, callback) {
 Database.prototype._openDatabase = function(dbName, flags) {
 	if (dbName === ":memory:") {
 		//noinspection JSUnresolvedVariable
-		return android.database.sqlite.SQLiteDatabase.create(flags);
+		return android.database.sqlite.SQLiteDatabase.create(null);
 	} else {
 		//noinspection JSUnresolvedVariable,JSUnresolvedFunction
 		return android.database.sqlite.SQLiteDatabase.openDatabase(dbName, null, flags | 0x10000000);


### PR DESCRIPTION
Proposed fix for Issue #157

I was not able to test this on iOS: The new unit tests might fail there.
